### PR TITLE
Remove an unnecessary check from IsValidClient

### DIFF
--- a/scripting/retakes_hud.sp
+++ b/scripting/retakes_hud.sp
@@ -225,5 +225,5 @@ stock int GetNearestBombsite(int client)
 
 stock bool IsValidClient(int client)
 {
-	return client > 0 && client <= MaxClients && IsClientConnected(client) && IsClientInGame(client) && !IsFakeClient(client);
+	return client > 0 && client <= MaxClients && IsClientInGame(client) && !IsFakeClient(client);
 }


### PR DESCRIPTION
IsClientConnected is redundant as IsClientInGame already takes care of it.